### PR TITLE
ci(pr): deployment commit is now through a PR 

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -79,6 +79,9 @@ lane :deploy do |options|
 		path: "InstantSearchCoreOffline.podspec"
 	)
 
+	branchName = "version-#{new_build_number}"
+	sh("git checkout -b #{branchName}")
+
 	#puts changelog_from_git_commits
 	git_commit(
 		path: ["InstantSearchCore.podspec", "InstantSearchCoreOffline.podspec", "Sources/Info.plist" ,"Tests/Info.plist"], 
@@ -89,6 +92,17 @@ lane :deploy do |options|
 		tag: new_build_number
 	)
 	push_to_git_remote(remote: "origin")
+
+	create_pull_request(
+		# api_token: "secret",      # optional, defaults to ENV["GITHUB_API_TOKEN"]
+		repo: "algolia/instantsearch-core-swift",
+		title: "Deploying new #{options[:type]} version #{new_build_number}",
+		head: "#{branchName}",       # optional, defaults to current branch name
+		base: "master", # optional, defaults to "master"
+		body: "Please check the files before merging in case I've overidden something accidentally.",       # optional
+		# api_url: "http://yourdomain/api/v3" # optional, for GitHub Enterprise, defaults to "https://api.github.com"
+	)
+
 	pod_push(
 		path: "InstantSearchCore.podspec"
 	)


### PR DESCRIPTION
deployment commit is now through a PR instead of force push due to protected branch