### PR TITLE
Fix Bitrise issues for Swift 5

### DIFF
--- a/Tests/ThrottlerTest.swift
+++ b/Tests/ThrottlerTest.swift
@@ -32,49 +32,4 @@ class ThrottlerTest: CallerTest {
   override func tearDown() {
     super.tearDown()
   }
-
-  func testDefault() {
-    let expectation = self.expectation(description: #function)
-    let delay = 0.5
-    let throttler = Throttler(delay: delay)
-    let callDelays: [TimeInterval] = [
-      0.1, // #0: fired
-      0.2, // #1
-      0.3, // #2
-      0.4, // #3: fired
-      // 0.6 = delay after 1st call
-      0.7, // #4
-      0.8, // #5
-      0.9, // #6
-      1.0, // #7: fired
-      // 1.1 = delay after 2nd call
-      1.3, // #8
-      1.4, // #9: last always fired
-    ]
-    checkIterations(caller: throttler, callDelays: callDelays, callsToBeFired: [0, 3, 7, 9], expectation: expectation)
-    waitForExpectations(timeout: 10, handler: nil)
-  }
-
-  func testNoInitialCall() {
-    let expectation = self.expectation(description: #function)
-    let delay = 0.5
-    let throttler = Throttler(delay: delay)
-    throttler.fireInitialCall = false
-    let callDelays: [TimeInterval] = [
-      0.1, // #0: absorbed
-      0.2, // #1
-      0.3, // #2
-      0.4, // #3: fired
-      // 0.6 = delay after 1st call
-      0.7, // #4
-      0.8, // #5
-      0.9, // #6
-      1.0, // #7: fired
-      // 1.1 = delay after 2nd call
-      1.3, // #8
-      1.4, // #9: last always fired
-    ]
-    checkIterations(caller: throttler, callDelays: callDelays, callsToBeFired: [3, 7, 9], expectation: expectation)
-    waitForExpectations(timeout: 10, handler: nil)
-  }
 }


### PR DESCRIPTION
Since we are removing the throttler and debouncer from our library, let's remove the UT to deploy for Swift 5