### PR TITLE
remove extra initial reload of facet list

### DIFF
--- a/Sources/FacetList/FacetListInteractor+Controller.swift
+++ b/Sources/FacetList/FacetListInteractor+Controller.swift
@@ -25,9 +25,7 @@ public extension FacetListInteractor {
       controller.setSelectableItems(selectableItems: sortedFacetValues)
       controller.reload()
     }
-    
-    setControllerItemsWith(facets: items, selections: selections)
-    
+        
     controller.onClick = { [weak self] facet in
       self?.computeSelections(selectingItemForKey: facet.value)
     }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Remove the extra reload with 0 item when setting up a facet list. 

Note that we should not remove it for the FilterList as the items are specified locally and not fetched from the server, so we need to reload directly with the new locally specified items 

