### PR TITLE
fix marketing version for bitrise

### DIFF
--- a/InstantSearchCore.xcodeproj/project.pbxproj
+++ b/InstantSearchCore.xcodeproj/project.pbxproj
@@ -3350,6 +3350,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MARKETING_VERSION = 6.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.algolia.InstantSearchCore;
 				PRODUCT_NAME = InstantSearchCore;
 				SDKROOT = macosx;
@@ -3381,6 +3382,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MARKETING_VERSION = 6.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.algolia.InstantSearchCore;
 				PRODUCT_NAME = InstantSearchCore;
 				SDKROOT = macosx;
@@ -3462,6 +3464,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 6.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.algolia.InstantSearchCore;
 				PRODUCT_NAME = InstantSearchCore;
 				SDKROOT = appletvos;
@@ -3492,6 +3495,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 6.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.algolia.InstantSearchCore;
 				PRODUCT_NAME = InstantSearchCore;
 				SDKROOT = appletvos;
@@ -3576,6 +3580,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 6.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.algolia.InstantSearchCore;
 				PRODUCT_NAME = InstantSearchCore;
 				SDKROOT = watchos;
@@ -3613,6 +3618,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 6.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.algolia.InstantSearchCore;
 				PRODUCT_NAME = InstantSearchCore;
 				SDKROOT = watchos;

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>6.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Fixing Bitrise issue of: 

> Your current version ($(MARKETING_VERSION)) does not respect the format A or A.B or A.B.C

![image](https://user-images.githubusercontent.com/1502519/71002317-496e9080-20df-11ea-8307-f44175996667.png)

The Marketing Version was only set for iOS target but not the others. 