### PR TITLE
feat(related-items): implement connectSearcher for related Items

### DIFF
--- a/InstantSearchCore.xcodeproj/project.pbxproj
+++ b/InstantSearchCore.xcodeproj/project.pbxproj
@@ -7,6 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5298C7FD24519D9700B82659 /* MatchingPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5298C7FC24519D9700B82659 /* MatchingPattern.swift */; };
+		5298C7FE24519D9700B82659 /* MatchingPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5298C7FC24519D9700B82659 /* MatchingPattern.swift */; };
+		5298C7FF24519D9700B82659 /* MatchingPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5298C7FC24519D9700B82659 /* MatchingPattern.swift */; };
+		5298C80024519D9700B82659 /* MatchingPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5298C7FC24519D9700B82659 /* MatchingPattern.swift */; };
+		5298C80224519DC100B82659 /* RelatedItemsInteractor+SingleIndexSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5298C80124519DC000B82659 /* RelatedItemsInteractor+SingleIndexSearcher.swift */; };
+		5298C80324519DC100B82659 /* RelatedItemsInteractor+SingleIndexSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5298C80124519DC000B82659 /* RelatedItemsInteractor+SingleIndexSearcher.swift */; };
+		5298C80424519DC100B82659 /* RelatedItemsInteractor+SingleIndexSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5298C80124519DC000B82659 /* RelatedItemsInteractor+SingleIndexSearcher.swift */; };
+		5298C80524519DC100B82659 /* RelatedItemsInteractor+SingleIndexSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5298C80124519DC000B82659 /* RelatedItemsInteractor+SingleIndexSearcher.swift */; };
+		5298C80B2451A40B00B82659 /* HitsInteractorRelatedItemsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5298C8062451A33400B82659 /* HitsInteractorRelatedItemsTests.swift */; };
+		5298C80C2451A40C00B82659 /* HitsInteractorRelatedItemsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5298C8062451A33400B82659 /* HitsInteractorRelatedItemsTests.swift */; };
+		5298C80D2451A40D00B82659 /* HitsInteractorRelatedItemsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5298C8062451A33400B82659 /* HitsInteractorRelatedItemsTests.swift */; };
 		AF02394C230A897D001471CF /* Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF02394B230A897D001471CF /* Connection.swift */; };
 		AF02394D230A897D001471CF /* Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF02394B230A897D001471CF /* Connection.swift */; };
 		AF02394E230A897D001471CF /* Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF02394B230A897D001471CF /* Connection.swift */; };
@@ -1105,6 +1116,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5298C7FC24519D9700B82659 /* MatchingPattern.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchingPattern.swift; sourceTree = "<group>"; };
+		5298C80124519DC000B82659 /* RelatedItemsInteractor+SingleIndexSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RelatedItemsInteractor+SingleIndexSearcher.swift"; sourceTree = "<group>"; };
+		5298C8062451A33400B82659 /* HitsInteractorRelatedItemsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HitsInteractorRelatedItemsTests.swift; sourceTree = "<group>"; };
 		AF02394B230A897D001471CF /* Connection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Connection.swift; sourceTree = "<group>"; };
 		AF06184622E9F3D000FDBAAE /* HitsInteractor+SingleIndexSearcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "HitsInteractor+SingleIndexSearcher.swift"; sourceTree = "<group>"; };
 		AF06184D22EA2ED200FDBAAE /* MultiIndexHitsInteractor+Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MultiIndexHitsInteractor+Controller.swift"; sourceTree = "<group>"; };
@@ -1470,6 +1484,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5298C7FB24519D7D00B82659 /* Related Items */ = {
+			isa = PBXGroup;
+			children = (
+				5298C7FC24519D9700B82659 /* MatchingPattern.swift */,
+				5298C80124519DC000B82659 /* RelatedItemsInteractor+SingleIndexSearcher.swift */,
+			);
+			path = "Related Items";
+			sourceTree = "<group>";
+		};
 		AF1177A5225E2B2300C5B59B /* FilterState */ = {
 			isa = PBXGroup;
 			children = (
@@ -1548,6 +1571,7 @@
 				AF28646A239571F000E9E845 /* HitsInteractorControllerConnectionTests.swift */,
 				AF2864622395212000E9E845 /* TestInfiniteScrollingController.swift */,
 				AF28646E239572B800E9E845 /* TestHitsController.swift */,
+				5298C8062451A33400B82659 /* HitsInteractorRelatedItemsTests.swift */,
 			);
 			path = Hits;
 			sourceTree = "<group>";
@@ -1945,6 +1969,7 @@
 		AFF1E74B2296966400941401 /* Hits */ = {
 			isa = PBXGroup;
 			children = (
+				5298C7FB24519D7D00B82659 /* Related Items */,
 				E2E09E282231793C00F3056D /* HitsInteractor.swift */,
 				AF06184622E9F3D000FDBAAE /* HitsInteractor+SingleIndexSearcher.swift */,
 				AF5808702318243A00C5BDFA /* HitsInteractor+PlacesSearcher.swift */,
@@ -2636,6 +2661,7 @@
 				AF8D1C1223E09CAE00CB415F /* TestCurrentFiltersController.swift in Sources */,
 				AFC68D6923C6218F006841EF /* PageMapTests.swift in Sources */,
 				AFC68D8823C621CD006841EF /* FacetListPresenterTests.swift in Sources */,
+				5298C80C2451A40C00B82659 /* HitsInteractorRelatedItemsTests.swift in Sources */,
 				AFC68D9123C621D2006841EF /* DisjuncitveAndHierarchicalIntegrationTests.swift in Sources */,
 				AF102DF523F53C420034EB48 /* TestFiltersTracker.swift in Sources */,
 				AFC68D7823C621BE006841EF /* HitsInteractorTests.swift in Sources */,
@@ -2738,7 +2764,9 @@
 				AF2863FF238D807500E9E845 /* FilterListConnector.swift in Sources */,
 				AFCB30A222CB85A40094ED2E /* QueryBuilder.swift in Sources */,
 				AF1177B2225E2B7F00C5B59B /* NumericFilter.swift in Sources */,
+				5298C7FD24519D9700B82659 /* MatchingPattern.swift in Sources */,
 				AF8DA20022E11D7B00C3C03C /* FilterGroupsConvertible.swift in Sources */,
+				5298C80224519DC100B82659 /* RelatedItemsInteractor+SingleIndexSearcher.swift in Sources */,
 				AF5D105822F48AEE00DE13AA /* SelectableFilterInteractor+FilterState.swift in Sources */,
 				AF4E2A672344FC2E003EC036 /* HitsInteractor+GeoHitsController.swift in Sources */,
 				AF5DAA8822F6E326000DDB27 /* SingleIndexSearcher+FilterState.swift in Sources */,
@@ -2920,6 +2948,7 @@
 				AFC60950237F1B2500B10B58 /* FacetListPresenterTests.swift in Sources */,
 				AFC1566523980AAD008AC1A0 /* TestQueryInputController.swift in Sources */,
 				AFC60951237F1B2500B10B58 /* SearchResultsTests.swift in Sources */,
+				5298C80D2451A40D00B82659 /* HitsInteractorRelatedItemsTests.swift in Sources */,
 				AFC1567223981FBD008AC1A0 /* FacetListFacetSearcherConnectionTests.swift in Sources */,
 				AFC60952237F1B2500B10B58 /* SelectableInteractorConnectorsTests.swift in Sources */,
 				AF8D1C0923E0936F00CB415F /* CurrentFiltersFilterStateConnectionTests.swift in Sources */,
@@ -3022,7 +3051,9 @@
 				E25D634322D36AD8008CD0FD /* HierarchicalController.swift in Sources */,
 				AF5D105922F48AEE00DE13AA /* SelectableFilterInteractor+FilterState.swift in Sources */,
 				E2146BF222B3C56F00927350 /* NumberRangeInteractor.swift in Sources */,
+				5298C7FE24519D9700B82659 /* MatchingPattern.swift in Sources */,
 				AF5DAA8922F6E326000DDB27 /* SingleIndexSearcher+FilterState.swift in Sources */,
+				5298C80324519DC100B82659 /* RelatedItemsInteractor+SingleIndexSearcher.swift in Sources */,
 				AF4E2A682344FC2E003EC036 /* HitsInteractor+GeoHitsController.swift in Sources */,
 				AF322D2922D8BD8300010428 /* HierarchicalGroupAccessor.swift in Sources */,
 				E2146C2922CD0F5500927350 /* HierarchicalInteractor+Searcher.swift in Sources */,
@@ -3236,7 +3267,9 @@
 				E25D634422D36AD8008CD0FD /* HierarchicalController.swift in Sources */,
 				AF5D105A22F48AEE00DE13AA /* SelectableFilterInteractor+FilterState.swift in Sources */,
 				E2146BF322B3C56F00927350 /* NumberRangeInteractor.swift in Sources */,
+				5298C7FF24519D9700B82659 /* MatchingPattern.swift in Sources */,
 				AF5DAA8A22F6E326000DDB27 /* SingleIndexSearcher+FilterState.swift in Sources */,
+				5298C80424519DC100B82659 /* RelatedItemsInteractor+SingleIndexSearcher.swift in Sources */,
 				AF4E2A692344FC2E003EC036 /* HitsInteractor+GeoHitsController.swift in Sources */,
 				AF322D2A22D8BD8300010428 /* HierarchicalGroupAccessor.swift in Sources */,
 				E2146C2A22CD0F5500927350 /* HierarchicalInteractor+Searcher.swift in Sources */,
@@ -3418,6 +3451,7 @@
 				AFC6090C237F1B0D00B10B58 /* FacetListPresenterTests.swift in Sources */,
 				AFC1566723980AAD008AC1A0 /* TestQueryInputController.swift in Sources */,
 				AFC6090D237F1B0D00B10B58 /* SearchResultsTests.swift in Sources */,
+				5298C80B2451A40B00B82659 /* HitsInteractorRelatedItemsTests.swift in Sources */,
 				AFC1567423981FBD008AC1A0 /* FacetListFacetSearcherConnectionTests.swift in Sources */,
 				AFC6090E237F1B0D00B10B58 /* SelectableInteractorConnectorsTests.swift in Sources */,
 				AF8D1C0B23E0936F00CB415F /* CurrentFiltersFilterStateConnectionTests.swift in Sources */,
@@ -3520,7 +3554,9 @@
 				AF5D105B22F48AEE00DE13AA /* SelectableFilterInteractor+FilterState.swift in Sources */,
 				E2146BF422B3C56F00927350 /* NumberRangeInteractor.swift in Sources */,
 				AF5DAA8B22F6E326000DDB27 /* SingleIndexSearcher+FilterState.swift in Sources */,
+				5298C80024519D9700B82659 /* MatchingPattern.swift in Sources */,
 				AF322D2B22D8BD8300010428 /* HierarchicalGroupAccessor.swift in Sources */,
+				5298C80524519DC100B82659 /* RelatedItemsInteractor+SingleIndexSearcher.swift in Sources */,
 				AF4E2A6A2344FC2E003EC036 /* HitsInteractor+GeoHitsController.swift in Sources */,
 				E2146C2B22CD0F5500927350 /* HierarchicalInteractor+Searcher.swift in Sources */,
 				E2146BF922B3CC2E00927350 /* Boundable.swift in Sources */,

--- a/Sources/Hits/Related Items/MatchingPattern.swift
+++ b/Sources/Hits/Related Items/MatchingPattern.swift
@@ -1,0 +1,32 @@
+//
+//  MatchingPattern.swift
+//  InstantSearchCore
+//
+//  Created by test test on 23/04/2020.
+//  Copyright © 2020 Algolia. All rights reserved.
+//
+
+import Foundation
+
+public struct MatchingPattern<Model> {
+  let attribute: Attribute
+  let score: Int
+  let oneOrManyElementsInKeyPath: OneOrManyElementsInKeyPath<Model, String>
+  
+  public init(attribute: Attribute, score: Int, filterPath: KeyPath<Model, String>) {
+    self.attribute = attribute
+    self.score = score
+    self.oneOrManyElementsInKeyPath = .one(filterPath)
+  }
+  
+  public init(attribute: Attribute, score: Int, filterPath: KeyPath<Model, [String]>) {
+    self.attribute = attribute
+    self.score = score
+    self.oneOrManyElementsInKeyPath = .many(filterPath)
+  }
+  
+  enum OneOrManyElementsInKeyPath<T, V> {
+    case one(KeyPath<T, V>)
+    case many(KeyPath<T, [V]>)
+  }
+}

--- a/Sources/Hits/Related Items/RelatedItemsInteractor+SingleIndexSearcher.swift
+++ b/Sources/Hits/Related Items/RelatedItemsInteractor+SingleIndexSearcher.swift
@@ -1,0 +1,67 @@
+//
+//  RelatedItemsInteractor+SingleIndexSearcher.swift
+//  InstantSearchCore
+//
+//  Created by test test on 23/04/2020.
+//  Copyright © 2020 Algolia. All rights reserved.
+//
+
+import Foundation
+
+extension HitsInteractor {
+  
+  @discardableResult public func connectSearcher<T>(_ searcher: SingleIndexSearcher, withRelatedItemsTo hit: Hit<T>, with matchingPatterns: [MatchingPattern<T>]) -> SingleIndexSearcherConnection {
+    let connection = SingleIndexSearcherConnection(interactor: self, searcher: searcher)
+    connection.connect()
+        
+    let legacyFilters = generateOptionalFilters(from: matchingPatterns, and: hit)
+    
+    // Temporary workaround as the api client only accepts optionalFilters [Stirng] and not [[String]] for now...
+    let reducedOptionalFilters = convertLegacy2DArrayTo1DArray(with: legacyFilters)
+    
+    searcher.indexQueryState.query.sumOrFiltersScores = true
+    searcher.indexQueryState.query.facetFilters = ["objectID:-\(hit.objectID)"]
+    searcher.indexQueryState.query.optionalFilters = reducedOptionalFilters
+    
+    return connection
+  }
+  
+  func generateOptionalFilters<T>(from matchingPatterns: [MatchingPattern<T>], and hit: Hit<T>) -> [[String]]? {
+    let filterState = FilterState()
+    
+    for matchingPattern in matchingPatterns {
+      switch matchingPattern.oneOrManyElementsInKeyPath {
+      case .one(let keyPath): // // in the case of a single facet associated to a filter -> AND Behaviours
+        let facetValue = hit.object[keyPath: keyPath]
+        let facetFilter = Filter.Facet.init(attribute: matchingPattern.attribute, value: .string(facetValue), score: matchingPattern.score)
+        filterState[and: matchingPattern.attribute.name].add(facetFilter)
+      case .many(let keyPath): // in the case of multiple facets associated to a filter -> OR Behaviours
+        let facetFilters = hit.object[keyPath: keyPath].map { Filter.Facet.init(attribute: matchingPattern.attribute, value: .string($0), score: matchingPattern.score) }
+        filterState[or: matchingPattern.attribute.name].addAll(facetFilters)
+      }
+    }
+    
+    return FilterGroupConverter().legacy(filterState.toFilterGroups())
+  }
+  
+  func convertLegacy2DArrayTo1DArray(with legacyFilters: [[String]]?) -> [String] {
+    var reducedOptionalFilters: [String] = []
+    if let legacyFilters = legacyFilters {
+    
+      for legacyFilter in legacyFilters {
+        if legacyFilter.count == 1 {
+          let string = legacyFilter.first!
+          reducedOptionalFilters.append(string)
+        } else if legacyFilter.count > 1 {
+          let string = "[\(legacyFilter.joined(separator: ","))]" // we won't be doing this hack once we use [[String]] for optionalFilters in new client.
+          if let escapedString = string.addingPercentEncoding(withAllowedCharacters: .alphanumerics) {
+            reducedOptionalFilters.append(escapedString)
+          }
+        }
+      }
+    }
+    
+    return reducedOptionalFilters
+  }
+  
+}

--- a/Tests/Sources/Hits/HitsInteractorRelatedItemsTests.swift
+++ b/Tests/Sources/Hits/HitsInteractorRelatedItemsTests.swift
@@ -1,0 +1,48 @@
+//
+//  HitsInteractorRelatedItemsTests.swift
+//  InstantSearchCore
+//
+//  Created by test test on 23/04/2020.
+//  Copyright © 2020 Algolia. All rights reserved.
+//
+
+import Foundation
+
+import Foundation
+import XCTest
+@testable import InstantSearchCore
+
+class HitsInteractorRelatedItemsTests: XCTestCase {
+    
+  struct Product: Codable {
+    let name: String
+    let brand: String
+    let type: String
+    let categories: [String]
+    let image: URL
+  }
+  
+  func testConnect() {
+    let matchingPatterns: [MatchingPattern<Product>] =
+      [
+        MatchingPattern(attribute: "brand", score: 3, filterPath: \.brand),
+        MatchingPattern(attribute: "type", score: 10, filterPath: \.type),
+        MatchingPattern(attribute: "categories", score: 2, filterPath: \.categories),
+      ]
+
+    let searcher = SingleIndexSearcher(index: .test)
+    let product = Product.init(name: "productName", brand: "Amazon", type: "Streaming media plyr", categories: ["Streaming Media Players", "TV & Home Theater"], image: URL.init(string: "http://url.com")!)
+    
+    let hitsInteractor = HitsInteractor<JSON>.init()
+    
+    let hit: Hit<Product> = .init(objectID: "objectID123", object: product)
+    hitsInteractor.connectSearcher(searcher, withRelatedItemsTo: hit, with: matchingPatterns)
+    
+    let expectedOptionalFilter = ["brand:Amazon<score=3>", "%5Bcategories%3AStreaming%20Media%20Players%3Cscore%3D2%3E%2Ccategories%3ATV%20%26%20Home%20Theater%3Cscore%3D2%3E%5D", "type:Streaming media plyr<score=10>"]
+    
+    XCTAssertEqual(searcher.indexQueryState.query.sumOrFiltersScores, true)
+    XCTAssertEqual(searcher.indexQueryState.query.optionalFilters, expectedOptionalFilter)
+    XCTAssertEqual(searcher.indexQueryState.query.facetFilters as! [String], ["objectID:-objectID123"])
+    
+  }
+}


### PR DESCRIPTION
Follows similar API as the [JS related Item widget](https://www.algolia.com/doc/api-reference/widgets/configure-related-items/js/).

This is how the DX looks, using keypath for specifying the score for each optional filter 
```swift
struct Product: Codable {
    let name: String
    let brand: String
    let type: String
    let categories: [String]
    let image: URL
  }

   let matchingPatterns: [MatchingPattern<Product>] =
      [
        MatchingPattern(attribute: "brand", score: 3, filterPath: \.brand),
        MatchingPattern(attribute: "type", score: 10, filterPath: \.type),
        MatchingPattern(attribute: "categories", score: 2, filterPath: \.categories),
      ]

    let searcher = SingleIndexSearcher(index: .test)
    let product = Product.init()
    let hitsInteractor = HitsInteractor<JSON>.init()
    let hit: Hit<Product> = .init(objectID: "objectID", object: product)
    hitsInteractor.connectSearcher(searcher, withRelatedItemsTo: hit, with: matchingPatterns)
   searcher.search()
```